### PR TITLE
rsx: Async shader compilation

### DIFF
--- a/rpcs3/Emu/RSX/CgBinaryProgram.h
+++ b/rpcs3/Emu/RSX/CgBinaryProgram.h
@@ -335,7 +335,7 @@ public:
 				u32 ctrl = (vmfprog.outputFromH0 ? 0 : 0x40) | (vmfprog.depthReplace ? 0xe : 0);
 				std::vector<rsx::texture_dimension_extended> td;
 				RSXFragmentProgram prog;
-				prog.size = 0, prog.addr = vm::base(ptr + vmprog.ucode), prog.offset = 0, prog.ctrl = ctrl;
+				prog.ucode_length = 0, prog.addr = vm::base(ptr + vmprog.ucode), prog.offset = 0, prog.ctrl = ctrl;
 				GLFragmentDecompilerThread(m_glsl_shader, param_array, prog, size).Task();
 				vm::close();
 			}

--- a/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Common/ProgramStateCache.cpp
@@ -326,20 +326,20 @@ size_t fragment_program_utils::get_fragment_program_ucode_size(void *ptr)
 fragment_program_utils::fragment_program_metadata fragment_program_utils::analyse_fragment_program(void *ptr)
 {
 	const qword *instBuffer = (const qword*)ptr;
-	size_t instIndex = 0;
+	s32 index = 0;
 	s32 program_offset = -1;
 	u32 ucode_size = 0;
 	u16 textures_mask = 0;
 
 	while (true)
 	{
-		const qword& inst = instBuffer[instIndex];
+		const qword& inst = instBuffer[index];
 		const u32 opcode = (inst.word[0] >> 16) & 0x3F;
 
 		if (opcode)
 		{
 			if (program_offset < 0)
-				program_offset = instIndex * 16;
+				program_offset = index * 16;
 
 			switch(opcode)
 			{
@@ -362,7 +362,7 @@ fragment_program_utils::fragment_program_metadata fragment_program_utils::analys
 			if (is_constant(inst.word[1]) || is_constant(inst.word[2]) || is_constant(inst.word[3]))
 			{
 				//Instruction references constant, skip one slot occupied by data
-				instIndex++;
+				index++;
 				ucode_size += 16;
 			}
 		}
@@ -376,14 +376,14 @@ fragment_program_utils::fragment_program_metadata fragment_program_utils::analys
 		{
 			if (program_offset < 0)
 			{
-				program_offset = instIndex * 16;
+				program_offset = index * 16;
 				ucode_size = 16;
 			}
 
 			break;
 		}
 
-		instIndex++;
+		index++;
 	}
 
 	return{ (u32)program_offset, ucode_size, textures_mask };

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -310,7 +310,7 @@ void D3D12GSRender::load_program()
 		}
 	}
 
-	m_current_pso = m_pso_cache.getGraphicPipelineState(current_vertex_program, current_fragment_program, prop, m_device.Get(), m_shared_root_signature.Get());
+	m_current_pso = m_pso_cache.get_graphics_pipeline(current_vertex_program, current_fragment_program, prop, false, m_device.Get(), m_shared_root_signature.Get());
 	return;
 }
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -329,6 +329,7 @@ private:
 	std::thread::id m_thread_id;
 
 	GLProgramBuffer m_prog_buffer;
+	draw_context_t m_decompiler_context;
 
 	//buffer
 	gl::fbo draw_fbo;
@@ -361,7 +362,8 @@ private:
 	void init_buffers(rsx::framebuffer_creation_context context, bool skip_reading = false);
 
 	bool check_program_state();
-	void load_program(const gl::vertex_upload_info& upload_info);
+	bool load_program();
+	void load_program_env(const gl::vertex_upload_info& upload_info);
 
 	void update_draw_state();
 
@@ -398,4 +400,8 @@ protected:
 
 	std::array<std::vector<gsl::byte>, 4> copy_render_targets_to_memory() override;
 	std::array<std::vector<gsl::byte>, 2> copy_depth_stencil_buffer_to_memory() override;
+
+	void on_decompiler_init() override;
+	void on_decompiler_exit() override;
+	bool on_decompiler_task() override;
 };

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -32,7 +32,11 @@ namespace rsx
 		{
 			if (auto rsxthr = rsx::get_current_renderer())
 			{
-				rsxthr->native_ui_flip_request.store(true);
+				const auto now = get_system_time() - 1000000;
+				if ((now - rsxthr->last_flip_time) > min_refresh_duration_us)
+				{
+					rsxthr->native_ui_flip_request.store(true);
+				}
 			}
 		}
 	} // namespace overlays

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -32,6 +32,8 @@ namespace rsx
 			u16 virtual_width = 1280;
 			u16 virtual_height = 720;
 
+			u32 min_refresh_duration_us = 16600;
+
 			virtual ~overlay() = default;
 
 			virtual void update() {}
@@ -1103,6 +1105,9 @@ namespace rsx
 
 				creation_time = get_system_time();
 				expire_time = creation_time + 1000000;
+
+				// Disable forced refresh unless fps dips below 4
+				min_refresh_duration_us = 250000;
 			}
 
 			void update_animation(u64 t)

--- a/rpcs3/Emu/RSX/RSXFragmentProgram.h
+++ b/rpcs3/Emu/RSX/RSXFragmentProgram.h
@@ -216,9 +216,9 @@ static const std::string rsx_fp_op_names[] =
 
 struct RSXFragmentProgram
 {
-	u32 size;
 	void *addr;
 	u32 offset;
+	u32 ucode_length;
 	u32 ctrl;
 	u16 unnormalized_coords;
 	u16 redirected_textures;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -275,6 +275,7 @@ namespace rsx
 	class thread : public named_thread
 	{
 		std::shared_ptr<thread_ctrl> m_vblank_thread;
+		std::shared_ptr<thread_ctrl> m_decompiler_thread;
 
 	protected:
 		atomic_t<bool> m_rsx_thread_exiting{false};
@@ -423,6 +424,10 @@ namespace rsx
 		 * Execute a backend local task queue
 		 */
 		virtual void do_local_task(FIFO_state state);
+
+		virtual void on_decompiler_init() {}
+		virtual void on_decompiler_exit() {}
+		virtual bool on_decompiler_task() { return false; }
 
 	public:
 		virtual std::string get_name() const override;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -402,7 +402,8 @@ private:
 
 public:
 	bool check_program_status();
-	void load_program(const vk::vertex_upload_info& vertex_info);
+	bool load_program();
+	void load_program_env(const vk::vertex_upload_info& vertex_info);
 	void init_buffers(rsx::framebuffer_creation_context context, bool skip_reading = false);
 	void read_buffers();
 	void write_buffers();
@@ -429,4 +430,6 @@ protected:
 
 	bool on_access_violation(u32 address, bool is_writing) override;
 	void on_invalidate_memory_range(u32 address_base, u32 size) override;
+
+	bool on_decompiler_task() override;
 };

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -2282,10 +2282,13 @@ public:
 
 		graphics_pipeline_state()
 		{
-			ia = { VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO };
-			cs = { VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO };
-			ds = { VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO };
-			rs = { VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO };
+			// NOTE: Vk** structs have padding bytes
+			memset(this, 0, sizeof(graphics_pipeline_state));
+
+			ia.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+			cs.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+			ds.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+			rs.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
 
 			for (int i = 0; i < 4; ++i)
 			{
@@ -2298,8 +2301,37 @@ public:
 			rs.lineWidth = 1.f;
 		}
 
+		graphics_pipeline_state(const graphics_pipeline_state& other)
+		{
+			// NOTE: Vk** structs have padding bytes
+			memcpy(this, &other, sizeof(graphics_pipeline_state));
+
+			if (other.cs.pAttachments == other.att_state)
+			{
+				// Rebase pointer
+				cs.pAttachments = att_state;
+			}
+		}
+
 		~graphics_pipeline_state()
 		{}
+
+		graphics_pipeline_state& operator = (const graphics_pipeline_state& other)
+		{
+			if (this != &other)
+			{
+				// NOTE: Vk** structs have padding bytes
+				memcpy(this, &other, sizeof(graphics_pipeline_state));
+
+				if (other.cs.pAttachments == other.att_state)
+				{
+					// Rebase pointer
+					cs.pAttachments = att_state;
+				}
+			}
+
+			return *this;
+		}
 
 		void set_primitive_type(VkPrimitiveTopology type)
 		{

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -687,8 +687,7 @@ namespace rsx
 
 			if (!fs::is_file(fp_name))
 			{
-				const auto size = program_hash_util::fragment_program_utils::get_fragment_program_ucode_size(fp.addr);
-				fs::file(fp_name, fs::rewrite).write(fp.addr, size);
+				fs::file(fp_name, fs::rewrite).write(fp.addr, fp.ucode_length);
 			}
 
 			if (!fs::is_file(vp_name))
@@ -741,6 +740,7 @@ namespace rsx
 			RSXFragmentProgram fp = {};
 			fragment_program_data[program_hash] = data;
 			fp.addr = fragment_program_data[program_hash].data();
+			fp.ucode_length = (u32)data.size();
 
 			return fp;
 		}

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -402,8 +402,9 @@ struct cfg_root : cfg::node
 		cfg::_bool frame_skip_enabled{this, "Enable Frame Skip", false};
 		cfg::_bool force_cpu_blit_processing{this, "Force CPU Blit", false}; // Debugging option
 		cfg::_bool disable_on_disk_shader_cache{this, "Disable On-Disk Shader Cache", false};
-		cfg::_bool disable_vulkan_mem_allocator{ this, "Disable Vulkan Memory Allocator", false };
+		cfg::_bool disable_vulkan_mem_allocator{this, "Disable Vulkan Memory Allocator", false};
 		cfg::_bool full_rgb_range_output{this, "Use full RGB output range", true}; // Video out dynamic range
+		cfg::_bool disable_asynchronous_shader_compiler{this, "Disable Asynchronous Shader Compiler", false};
 		cfg::_int<1, 8> consequtive_frames_to_draw{this, "Consecutive Frames To Draw", 1};
 		cfg::_int<1, 8> consequtive_frames_to_skip{this, "Consecutive Frames To Skip", 1};
 		cfg::_int<50, 800> resolution_scale_percent{this, "Resolution Scale", 100};

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -93,6 +93,7 @@ int main(int argc, char** argv)
 
 	QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 	QCoreApplication::setAttribute(Qt::AA_DisableWindowContextHelpButton);
+	QCoreApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);
 
 	s_init.post();
 	s_qt_mutex.wait();

--- a/rpcs3/rpcs3qt/gl_gs_frame.h
+++ b/rpcs3/rpcs3qt/gl_gs_frame.h
@@ -3,10 +3,18 @@
 #include "stdafx.h"
 #include "gs_frame.h"
 
+struct GLContext
+{
+	QSurface *surface = nullptr;
+	QOpenGLContext *handle = nullptr;
+	bool owner = false;
+};
+
 class gl_gs_frame : public gs_frame
 {
 private:
 	QSurfaceFormat m_format;
+	GLContext *m_primary_context = nullptr;
 
 public:
 	gl_gs_frame(const QRect& geometry, QIcon appIcon, bool disableMouse);


### PR DESCRIPTION
- Defer compilation process to worker threads
- vulkan: Fixup for graphics_pipeline_state.
  Never use struct assignment operator on vk** structs due to padding after sType member (4 bytes)